### PR TITLE
Issue 21 - Adding --all, --good, and --bad flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This is a command line tool designed to report broken link and their status, suc
 * Find broken links for one or more file in one or more directory
 * Find broken links directly from one or more URL
 * Find archvied version of link directly from one or more URL
-* Prints good links or bad links or all links based on config file
+* Accepts configuration file for customizing result (good, bad, all links)
 
 ## Installation
 
@@ -64,12 +64,11 @@ $ fbl -a [url1] [url2]...
 To print specific type of URL(good/bad/all):
 
 ```sh
-$ fbl -c [path to json file]
-along with other options
+$ fbl -c [path to Config file] <another option>
 ```
-The structure of config file must follow the structure:
+The Config file must be a valid json with following structure:
 
-{"resultType" : "[type]"} where type can be `good` or `bad` or `all`
+{"resultType" : "[type]"} where type can be `good` or `bad` or `all`. You can change the resultType while testing.
 
 
 ### Options
@@ -78,12 +77,13 @@ The structure of config file must follow the structure:
 * `-d`, `--dir` : path to one or more directories you want to check for broken link
 * `-u`, `--url`: one or more URL you want to check for broken link
 * `-a`, `--archived`: one or more URL you want to check for archived version
+* `-c`, `--config`: uses the configuartion from specified file
 * `-v`, `--version`: prints current version number of the CLI with tool name
 * `-h`, `--help`: prints the options available for the CLI with the example of how to use it
 
 ## Testing
 
-For testing purposes, two test files(test.txt, test2.html) and one test directory have been provided.
+For testing purposes, two test files(test.txt, test2.html), one test directory, and a Config file have been provided.
 
 ## Improvement
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ This is a command line tool designed to report broken link and their status, suc
 * Find broken links for one or more file
 * Find broken links for one or more file in one or more directory
 * Find broken links directly from one or more URL
-* FInd archvied version of link directly from one or more URL
+* Find archvied version of link directly from one or more URL
+* Prints good links or bad links or all links based on config file
 
 ## Installation
 
@@ -60,6 +61,16 @@ To find an archived version of one or more URL:
 ```sh
 $ fbl -a [url1] [url2]... 
 ```
+To print specific type of URL(good/bad/all):
+
+```sh
+$ fbl -c [path to json file]
+along with other options
+```
+The structure of config file must follow the structure:
+
+{"resultType" : "[type]"} where type can be `good` or `bad` or `all`
+
 
 ### Options
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,6 +98,11 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
     "line-reader": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/line-reader/-/line-reader-0.4.0.tgz",
@@ -107,6 +112,20 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
       "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
+    "path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
+      "requires": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      }
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "readline": {
       "version": "1.3.0",
@@ -159,6 +178,14 @@
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "requires": {
         "has-flag": "^4.0.0"
+      }
+    },
+    "util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "requires": {
+        "inherits": "2.0.3"
       }
     },
     "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "fs": "0.0.1-security",
     "line-reader": "^0.4.0",
     "node-fetch": "^2.6.1",
+    "path": "^0.12.7",
     "readline": "^1.3.0",
     "yargs": "^16.0.3"
   }

--- a/src/fbl-config.json
+++ b/src/fbl-config.json
@@ -1,0 +1,1 @@
+{"resultType" : "good"}

--- a/src/fbl-config.json
+++ b/src/fbl-config.json
@@ -1,1 +1,1 @@
-{"resultType" : "good"}
+{"resultType" : "bad"}

--- a/src/index.js
+++ b/src/index.js
@@ -129,8 +129,7 @@ function handleArg(argv) {
 }
 //send http request and check the status
 function checkUrlAndReport(url) {
-     
-    fetch(url, { method: "head", timeout: 13000, redirect : "manual"})
+      fetch(url, { method: "head", timeout: 13000, redirect : "manual"})
         .then(function (response) {
              /*When -c only prints specific type URL, else prints normal way */
             if(!argv.c){
@@ -188,10 +187,6 @@ function readFile(fileNames) {
             }
         })
     })
-}
-
-//print link based on config file
-function printURL(configFile){
 }
 
 //archived version from wayback machine url


### PR DESCRIPTION
To add this feature, I create an option `-c`, `--config` which takes a configuration file where user can specify the URL result type that they want to see. The file must be a valid json which contains: 
{"resultType" : "[type]"}. Here type can be `good` or `bad` or `all`. This option is used with other available options
 
The logic I followed:

- Check if user calls `-c` option with the file name. If yes, go to next step. If no, call a setDefaultConfig( ) which will set the config's resultType to `all`.

- Check if the config file exists using `fs.existsSync`. If yes, check if the user provided absolute path or not. If not, get a absolute path using `path.resolve`. 

- Now, print the URL according to status code and resultType in the Config file.

closes #21 